### PR TITLE
[ISSUE #22] 编辑数据源时按需更改信息,验证数据源连接

### DIFF
--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/DatasourceService.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/DatasourceService.java
@@ -3,6 +3,7 @@ package com.hinadt.miaocha.application.service;
 import com.hinadt.miaocha.domain.dto.DatasourceConnectionTestResultDTO;
 import com.hinadt.miaocha.domain.dto.DatasourceCreateDTO;
 import com.hinadt.miaocha.domain.dto.DatasourceDTO;
+import com.hinadt.miaocha.domain.dto.DatasourceUpdateDTO;
 import com.hinadt.miaocha.domain.entity.DatasourceInfo;
 import java.util.List;
 
@@ -13,7 +14,7 @@ public interface DatasourceService {
     DatasourceDTO createDatasource(DatasourceCreateDTO dto);
 
     /** 更新数据源 */
-    DatasourceDTO updateDatasource(Long id, DatasourceCreateDTO dto);
+    DatasourceDTO updateDatasource(Long id, DatasourceUpdateDTO dto);
 
     /** 删除数据源 */
     void deleteDatasource(Long id);

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/DatasourceServiceImpl.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/DatasourceServiceImpl.java
@@ -78,8 +78,10 @@ public class DatasourceServiceImpl implements DatasourceService {
             }
         }
 
-        // 如果传入了密码或者JDBC URL，需要测试连接。使用更新后的信息进行测试
-        if (StringUtils.hasText(dto.getPassword()) || StringUtils.hasText(dto.getJdbcUrl())) {
+        // 如果传入了密码或者JDBC URL 不相同，需要测试连接。使用更新后的信息进行测试
+        if (StringUtils.hasText(dto.getPassword())
+                || (dto.getJdbcUrl() != null
+                        && !existingDatasourceInfo.getJdbcUrl().equals(dto.getJdbcUrl()))) {
             DatasourceCreateDTO testDto =
                     datasourceConverter.toCreateDTO(existingDatasourceInfo, dto);
             DatasourceConnectionTestResultDTO testResult = testConnection(testDto);

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/domain/converter/DatasourceConverter.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/domain/converter/DatasourceConverter.java
@@ -2,6 +2,7 @@ package com.hinadt.miaocha.domain.converter;
 
 import com.hinadt.miaocha.domain.dto.DatasourceCreateDTO;
 import com.hinadt.miaocha.domain.dto.DatasourceDTO;
+import com.hinadt.miaocha.domain.dto.DatasourceUpdateDTO;
 import com.hinadt.miaocha.domain.entity.DatasourceInfo;
 import com.hinadt.miaocha.domain.mapper.UserMapper;
 import org.springframework.stereotype.Component;
@@ -85,6 +86,49 @@ public class DatasourceConverter implements Converter<DatasourceInfo, Datasource
         return dto;
     }
 
+    /**
+     * 合并现有实体和更新DTO，创建一个用于连接测试的创建DTO.
+     *
+     * @param entity the existing entity
+     * @param dto the update DTO
+     * @return a new DatasourceCreateDTO for connection testing
+     */
+    public DatasourceCreateDTO toCreateDTO(DatasourceInfo entity, DatasourceUpdateDTO dto) {
+        if (entity == null || dto == null) {
+            return null;
+        }
+
+        DatasourceCreateDTO createDTO = new DatasourceCreateDTO();
+        createDTO.setName(entity.getName());
+        createDTO.setPassword(dto.getPassword());
+
+        if (dto.getType() != null) {
+            createDTO.setType(dto.getType());
+        } else {
+            createDTO.setType(entity.getType());
+        }
+
+        if (dto.getJdbcUrl() != null) {
+            createDTO.setJdbcUrl(dto.getJdbcUrl());
+        } else {
+            createDTO.setJdbcUrl(entity.getJdbcUrl());
+        }
+
+        if (dto.getUsername() != null) {
+            createDTO.setUsername(dto.getUsername());
+        } else {
+            createDTO.setUsername(entity.getUsername());
+        }
+
+        if (dto.getDescription() != null) {
+            createDTO.setDescription(dto.getDescription());
+        } else {
+            createDTO.setDescription(entity.getDescription());
+        }
+
+        return createDTO;
+    }
+
     /** 使用DTO更新实体 */
     @Override
     public DatasourceInfo updateEntity(DatasourceInfo entity, DatasourceDTO dto) {
@@ -112,6 +156,34 @@ public class DatasourceConverter implements Converter<DatasourceInfo, Datasource
         entity.setUsername(dto.getUsername());
         entity.setPassword(dto.getPassword());
         entity.setDescription(dto.getDescription());
+
+        return entity;
+    }
+
+    /** 使用更新DTO更新实体 */
+    public DatasourceInfo updateEntity(DatasourceInfo entity, DatasourceUpdateDTO dto) {
+        if (entity == null || dto == null) {
+            return entity;
+        }
+
+        if (dto.getName() != null) {
+            entity.setName(dto.getName());
+        }
+        if (dto.getType() != null) {
+            entity.setType(dto.getType());
+        }
+        if (dto.getJdbcUrl() != null) {
+            entity.setJdbcUrl(dto.getJdbcUrl());
+        }
+        if (dto.getUsername() != null) {
+            entity.setUsername(dto.getUsername());
+        }
+        if (dto.getPassword() != null) {
+            entity.setPassword(dto.getPassword());
+        }
+        if (dto.getDescription() != null) {
+            entity.setDescription(dto.getDescription());
+        }
 
         return entity;
     }

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/domain/dto/DatasourceUpdateDTO.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/domain/dto/DatasourceUpdateDTO.java
@@ -1,0 +1,29 @@
+package com.hinadt.miaocha.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/** 数据源更新DTO，用于接收更新请求 */
+@Data
+@Schema(description = "数据源更新请求对象")
+public class DatasourceUpdateDTO {
+    @Schema(description = "新的数据源名称", example = "测试Doris-更新")
+    private String name;
+
+    @Schema(description = "新的数据源类型", example = "DORIS")
+    private String type;
+
+    @Schema(description = "新的数据源描述", example = "更新后的Doris数据库")
+    private String description;
+
+    @Schema(
+            description = "新的JDBC连接URL",
+            example = "jdbc:mysql://192.168.1.101:9030/logs_db?connectTimeout=5000")
+    private String jdbcUrl;
+
+    @Schema(description = "新的数据源用户名", example = "new_admin")
+    private String username;
+
+    @Schema(description = "新的数据源密码，不提供则不更新", example = "new_password123")
+    private String password;
+}

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/endpoint/DatasourceEndpoint.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/endpoint/DatasourceEndpoint.java
@@ -5,6 +5,7 @@ import com.hinadt.miaocha.domain.dto.ApiResponse;
 import com.hinadt.miaocha.domain.dto.DatasourceConnectionTestResultDTO;
 import com.hinadt.miaocha.domain.dto.DatasourceCreateDTO;
 import com.hinadt.miaocha.domain.dto.DatasourceDTO;
+import com.hinadt.miaocha.domain.dto.DatasourceUpdateDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,7 +49,7 @@ public class DatasourceEndpoint {
     public ApiResponse<DatasourceDTO> updateDatasource(
             @Parameter(description = "数据源ID", required = true) @PathVariable("id") Long id,
             @Parameter(description = "数据源更新信息", required = true) @Valid @RequestBody
-                    DatasourceCreateDTO dto) {
+                    DatasourceUpdateDTO dto) {
         return ApiResponse.success(datasourceService.updateDatasource(id, dto));
     }
 

--- a/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/DatasourceInfoServiceTest.java
+++ b/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/DatasourceInfoServiceTest.java
@@ -12,6 +12,7 @@ import com.hinadt.miaocha.domain.converter.DatasourceConverter;
 import com.hinadt.miaocha.domain.dto.DatasourceConnectionTestResultDTO;
 import com.hinadt.miaocha.domain.dto.DatasourceCreateDTO;
 import com.hinadt.miaocha.domain.dto.DatasourceDTO;
+import com.hinadt.miaocha.domain.dto.DatasourceUpdateDTO;
 import com.hinadt.miaocha.domain.entity.DatasourceInfo;
 import com.hinadt.miaocha.domain.mapper.DatasourceMapper;
 import com.hinadt.miaocha.domain.mapper.ModuleInfoMapper;
@@ -20,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -50,6 +52,7 @@ class DatasourceInfoServiceTest {
     @Spy @InjectMocks private DatasourceServiceImpl datasourceService;
 
     private DatasourceCreateDTO createDTO;
+    private DatasourceUpdateDTO updateDTO;
     private DatasourceInfo existingDatasourceInfo;
     private DatasourceDTO datasourceDTO;
 
@@ -62,6 +65,15 @@ class DatasourceInfoServiceTest {
         createDTO.setJdbcUrl("jdbc:mysql://localhost:3306/test_db?useSSL=false&serverTimezone=UTC");
         createDTO.setUsername("root");
         createDTO.setPassword("password");
+
+        updateDTO = new DatasourceUpdateDTO();
+        updateDTO.setName("Updated Datasource");
+        updateDTO.setType("MySQL");
+        updateDTO.setJdbcUrl(
+                "jdbc:mysql://localhost:3306/updated_db?useSSL=false&serverTimezone=UTC");
+        updateDTO.setUsername("admin");
+        updateDTO.setPassword("newpassword");
+        updateDTO.setDescription("更新后的数据源");
 
         existingDatasourceInfo = new DatasourceInfo();
         existingDatasourceInfo.setId(1L);
@@ -86,6 +98,9 @@ class DatasourceInfoServiceTest {
                 .thenReturn(existingDatasourceInfo);
         when(datasourceConverter.updateEntity(
                         any(DatasourceInfo.class), any(DatasourceCreateDTO.class)))
+                .thenReturn(existingDatasourceInfo);
+        when(datasourceConverter.updateEntity(
+                        any(DatasourceInfo.class), any(DatasourceUpdateDTO.class)))
                 .thenReturn(existingDatasourceInfo);
     }
 
@@ -145,67 +160,244 @@ class DatasourceInfoServiceTest {
         verify(datasourceMapper, never()).insert(any(DatasourceInfo.class));
     }
 
-    @Test
-    void testUpdateDatasource_Success() {
-        // 模拟数据源存在
-        when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
-        // 模拟名称不重复
-        when(datasourceMapper.selectByName(anyString())).thenReturn(null);
-        // 模拟连接测试成功
-        doReturn(DatasourceConnectionTestResultDTO.success())
-                .when(datasourceService)
-                .testConnection(any(DatasourceCreateDTO.class));
-        // 模拟更新成功
-        when(datasourceMapper.update(any(DatasourceInfo.class))).thenReturn(1);
+    @Nested
+    @DisplayName("更新数据源测试")
+    class UpdateDatasourceTests {
 
-        DatasourceDTO result = datasourceService.updateDatasource(1L, createDTO);
+        @Test
+        @DisplayName("完整更新数据源 - 成功")
+        void testUpdateDatasource_FullUpdate_Success() {
+            // 模拟数据源存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
+            // 模拟名称不重复
+            when(datasourceMapper.selectByName(anyString())).thenReturn(null);
+            // 模拟连接测试成功
+            DatasourceCreateDTO testDTO = new DatasourceCreateDTO();
+            when(datasourceConverter.toCreateDTO(
+                            any(DatasourceInfo.class), any(DatasourceUpdateDTO.class)))
+                    .thenReturn(testDTO);
+            doReturn(DatasourceConnectionTestResultDTO.success())
+                    .when(datasourceService)
+                    .testConnection(any(DatasourceCreateDTO.class));
+            // 模拟更新成功
+            when(datasourceMapper.update(any(DatasourceInfo.class))).thenReturn(1);
 
-        assertNotNull(result);
-        assertEquals(createDTO.getName(), result.getName());
-        verify(datasourceMapper, times(1)).selectById(anyLong());
-        verify(datasourceMapper, times(1)).selectByName(anyString());
-        verify(datasourceService, times(1)).testConnection(any(DatasourceCreateDTO.class));
-        verify(datasourceMapper, times(1)).update(any(DatasourceInfo.class));
-    }
+            DatasourceDTO result = datasourceService.updateDatasource(1L, updateDTO);
 
-    @Test
-    void testUpdateDatasource_ConnectionFailed() {
-        // 模拟数据源存在
-        when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
-        // 模拟名称不重复
-        when(datasourceMapper.selectByName(anyString())).thenReturn(null);
-        // 模拟连接测试失败
-        doReturn(DatasourceConnectionTestResultDTO.failure("连接失败"))
-                .when(datasourceService)
-                .testConnection(any(DatasourceCreateDTO.class));
+            assertNotNull(result);
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            verify(datasourceMapper, times(1)).selectByName(anyString());
+            verify(datasourceService, times(1)).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, times(1)).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, times(1)).invalidateDataSourceById(1L);
+        }
 
-        assertThrows(
-                BusinessException.class,
-                () -> {
-                    datasourceService.updateDatasource(1L, createDTO);
-                });
+        @Test
+        @DisplayName("部分更新数据源 - 仅更新名称")
+        void testUpdateDatasource_PartialUpdate_NameOnly() {
+            DatasourceUpdateDTO partialDTO = new DatasourceUpdateDTO();
+            partialDTO.setName("New Name Only");
 
-        verify(datasourceMapper, times(1)).selectById(anyLong());
-        verify(datasourceMapper, times(1)).selectByName(anyString());
-        verify(datasourceService, times(1)).testConnection(any(DatasourceCreateDTO.class));
-        verify(datasourceMapper, never()).update(any(DatasourceInfo.class));
-    }
+            // 模拟数据源存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
+            // 模拟名称不重复
+            when(datasourceMapper.selectByName(anyString())).thenReturn(null);
+            // 模拟更新成功
+            when(datasourceMapper.update(any(DatasourceInfo.class))).thenReturn(1);
 
-    @Test
-    void testUpdateDatasource_NotFound() {
-        // 模拟数据源不存在
-        when(datasourceMapper.selectById(anyLong())).thenReturn(null);
+            DatasourceDTO result = datasourceService.updateDatasource(1L, partialDTO);
 
-        assertThrows(
-                BusinessException.class,
-                () -> {
-                    datasourceService.updateDatasource(1L, createDTO);
-                });
+            assertNotNull(result);
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            verify(datasourceMapper, times(1)).selectByName(anyString());
+            // 由于没有更新密码或JDBC URL，不应该进行连接测试
+            verify(datasourceService, never()).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, times(1)).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, times(1)).invalidateDataSourceById(1L);
+        }
 
-        verify(datasourceMapper, times(1)).selectById(anyLong());
-        verify(datasourceMapper, never()).selectByName(anyString());
-        verify(datasourceService, never()).testConnection(any(DatasourceCreateDTO.class));
-        verify(datasourceMapper, never()).update(any(DatasourceInfo.class));
+        @Test
+        @DisplayName("部分更新数据源 - 仅更新描述")
+        void testUpdateDatasource_PartialUpdate_DescriptionOnly() {
+            DatasourceUpdateDTO partialDTO = new DatasourceUpdateDTO();
+            partialDTO.setDescription("新的描述信息");
+
+            // 模拟数据源存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
+            // 模拟更新成功
+            when(datasourceMapper.update(any(DatasourceInfo.class))).thenReturn(1);
+
+            DatasourceDTO result = datasourceService.updateDatasource(1L, partialDTO);
+
+            assertNotNull(result);
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            // 由于没有更新名称，不需要检查名称重复
+            verify(datasourceMapper, never()).selectByName(anyString());
+            // 由于没有更新密码或JDBC URL，不应该进行连接测试
+            verify(datasourceService, never()).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, times(1)).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, times(1)).invalidateDataSourceById(1L);
+        }
+
+        @Test
+        @DisplayName("更新数据源密码 - 需要连接测试")
+        void testUpdateDatasource_UpdatePassword_RequiresConnectionTest() {
+            DatasourceUpdateDTO partialDTO = new DatasourceUpdateDTO();
+            partialDTO.setPassword("new_password");
+
+            // 模拟数据源存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
+            // 模拟连接测试成功
+            DatasourceCreateDTO testDTO = new DatasourceCreateDTO();
+            when(datasourceConverter.toCreateDTO(
+                            any(DatasourceInfo.class), any(DatasourceUpdateDTO.class)))
+                    .thenReturn(testDTO);
+            doReturn(DatasourceConnectionTestResultDTO.success())
+                    .when(datasourceService)
+                    .testConnection(any(DatasourceCreateDTO.class));
+            // 模拟更新成功
+            when(datasourceMapper.update(any(DatasourceInfo.class))).thenReturn(1);
+
+            DatasourceDTO result = datasourceService.updateDatasource(1L, partialDTO);
+
+            assertNotNull(result);
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            // 由于没有更新名称，不需要检查名称重复
+            verify(datasourceMapper, never()).selectByName(anyString());
+            // 由于更新了密码，需要进行连接测试
+            verify(datasourceService, times(1)).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, times(1)).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, times(1)).invalidateDataSourceById(1L);
+        }
+
+        @Test
+        @DisplayName("更新数据源JDBC URL - 需要连接测试")
+        void testUpdateDatasource_UpdateJdbcUrl_RequiresConnectionTest() {
+            DatasourceUpdateDTO partialDTO = new DatasourceUpdateDTO();
+            partialDTO.setJdbcUrl("jdbc:mysql://newhost:3306/newdb");
+
+            // 模拟数据源存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
+            // 模拟连接测试成功
+            DatasourceCreateDTO testDTO = new DatasourceCreateDTO();
+            when(datasourceConverter.toCreateDTO(
+                            any(DatasourceInfo.class), any(DatasourceUpdateDTO.class)))
+                    .thenReturn(testDTO);
+            doReturn(DatasourceConnectionTestResultDTO.success())
+                    .when(datasourceService)
+                    .testConnection(any(DatasourceCreateDTO.class));
+            // 模拟更新成功
+            when(datasourceMapper.update(any(DatasourceInfo.class))).thenReturn(1);
+
+            DatasourceDTO result = datasourceService.updateDatasource(1L, partialDTO);
+
+            assertNotNull(result);
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            // 由于没有更新名称，不需要检查名称重复
+            verify(datasourceMapper, never()).selectByName(anyString());
+            // 由于更新了JDBC URL，需要进行连接测试
+            verify(datasourceService, times(1)).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, times(1)).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, times(1)).invalidateDataSourceById(1L);
+        }
+
+        @Test
+        @DisplayName("更新数据源 - 连接测试失败")
+        void testUpdateDatasource_ConnectionFailed() {
+            // 模拟数据源存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
+            // 模拟名称不重复
+            when(datasourceMapper.selectByName(anyString())).thenReturn(null);
+            // 模拟连接测试失败
+            DatasourceCreateDTO testDTO = new DatasourceCreateDTO();
+            when(datasourceConverter.toCreateDTO(
+                            any(DatasourceInfo.class), any(DatasourceUpdateDTO.class)))
+                    .thenReturn(testDTO);
+            doReturn(DatasourceConnectionTestResultDTO.failure("连接失败"))
+                    .when(datasourceService)
+                    .testConnection(any(DatasourceCreateDTO.class));
+
+            assertThrows(
+                    BusinessException.class,
+                    () -> {
+                        datasourceService.updateDatasource(1L, updateDTO);
+                    });
+
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            verify(datasourceMapper, times(1)).selectByName(anyString());
+            verify(datasourceService, times(1)).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, never()).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, never()).invalidateDataSourceById(anyLong());
+        }
+
+        @Test
+        @DisplayName("更新数据源 - 名称重复")
+        void testUpdateDatasource_NameExists() {
+            DatasourceInfo anotherDatasource = new DatasourceInfo();
+            anotherDatasource.setId(2L);
+            anotherDatasource.setName("Updated Datasource");
+
+            // 模拟数据源存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
+            // 模拟名称重复
+            when(datasourceMapper.selectByName(anyString())).thenReturn(anotherDatasource);
+
+            assertThrows(
+                    BusinessException.class,
+                    () -> {
+                        datasourceService.updateDatasource(1L, updateDTO);
+                    });
+
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            verify(datasourceMapper, times(1)).selectByName(anyString());
+            verify(datasourceService, never()).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, never()).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, never()).invalidateDataSourceById(anyLong());
+        }
+
+        @Test
+        @DisplayName("更新数据源 - 数据源不存在")
+        void testUpdateDatasource_NotFound() {
+            // 模拟数据源不存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(null);
+
+            assertThrows(
+                    BusinessException.class,
+                    () -> {
+                        datasourceService.updateDatasource(1L, updateDTO);
+                    });
+
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            verify(datasourceMapper, never()).selectByName(anyString());
+            verify(datasourceService, never()).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, never()).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, never()).invalidateDataSourceById(anyLong());
+        }
+
+        @Test
+        @DisplayName("更新数据源 - 同名但同ID的情况")
+        void testUpdateDatasource_SameNameSameId() {
+            DatasourceUpdateDTO sameNameDTO = new DatasourceUpdateDTO();
+            sameNameDTO.setName("Test Datasource"); // 与现有数据源同名
+
+            // 模拟数据源存在
+            when(datasourceMapper.selectById(anyLong())).thenReturn(existingDatasourceInfo);
+            // 模拟查询到同名数据源（但是同一个ID）
+            when(datasourceMapper.selectByName(anyString())).thenReturn(existingDatasourceInfo);
+            // 模拟更新成功
+            when(datasourceMapper.update(any(DatasourceInfo.class))).thenReturn(1);
+
+            // 应该成功，因为是同一个数据源
+            DatasourceDTO result = datasourceService.updateDatasource(1L, sameNameDTO);
+
+            assertNotNull(result);
+            verify(datasourceMapper, times(1)).selectById(anyLong());
+            verify(datasourceMapper, times(1)).selectByName(anyString());
+            // 由于没有更新密码或JDBC URL，不应该进行连接测试
+            verify(datasourceService, never()).testConnection(any(DatasourceCreateDTO.class));
+            verify(datasourceMapper, times(1)).update(any(DatasourceInfo.class));
+            verify(hikariDatasourceManager, times(1)).invalidateDataSourceById(1L);
+        }
     }
 
     @Test
@@ -224,6 +416,7 @@ class DatasourceInfoServiceTest {
 
         verify(datasourceMapper, times(1)).selectById(anyLong());
         verify(moduleInfoMapper, times(1)).existsByDatasourceId(anyLong());
+        verify(hikariDatasourceManager, times(1)).invalidateDataSourceById(1L);
         verify(datasourceMapper, times(1)).deleteById(anyLong());
     }
 
@@ -240,6 +433,7 @@ class DatasourceInfoServiceTest {
 
         verify(datasourceMapper, times(1)).selectById(anyLong());
         verify(moduleInfoMapper, never()).existsByDatasourceId(anyLong());
+        verify(hikariDatasourceManager, never()).invalidateDataSourceById(anyLong());
         verify(datasourceMapper, never()).deleteById(anyLong());
     }
 
@@ -260,6 +454,7 @@ class DatasourceInfoServiceTest {
         assertEquals(ErrorCode.DATASOURCE_IN_USE, exception.getErrorCode());
         verify(datasourceMapper, times(1)).selectById(anyLong());
         verify(moduleInfoMapper, times(1)).existsByDatasourceId(anyLong());
+        verify(hikariDatasourceManager, never()).invalidateDataSourceById(anyLong());
         verify(datasourceMapper, never()).deleteById(anyLong());
     }
 


### PR DESCRIPTION
1. 调用编辑数据源信息接口，只有不为空的字段信息才会被更新
2. 更新数据源时，密码字段为空，JDBC URL和原来一样或者也为空，则不会触发验证连接，反之会触发验证数据源连接逻辑。
3. 优化相关单元测试
