### PR TITLE
[ISSUE #38] 超级管理员不可修改, 管理员无法修改非当前管理员信息

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ coverage-report
 version.txt
 
 k6/bin
+
+.history/

--- a/miaocha-ui/frontend/src/pages/system/UserManagement/components/UserFormModal.tsx
+++ b/miaocha-ui/frontend/src/pages/system/UserManagement/components/UserFormModal.tsx
@@ -27,6 +27,8 @@ const roleOptions = [
 ];
 
 const UserFormModal: React.FC<UserFormModalProps> = ({ visible, selectedRecord, onSubmit, onCancel, form }) => {
+  const isSuperAdmin = selectedRecord?.role === 'SUPER_ADMIN';
+  
   useEffect(() => {
     if (visible) {
       form.resetFields();
@@ -40,12 +42,14 @@ const UserFormModal: React.FC<UserFormModalProps> = ({ visible, selectedRecord, 
 
   return (
     <Modal
-      title={selectedRecord ? '编辑用户' : '添加用户'}
+      title={selectedRecord ? (isSuperAdmin ? '查看用户信息 (超级管理员不可编辑)' : '编辑用户') : '添加用户'}
       open={visible}
       onOk={onSubmit}
       onCancel={onCancel}
       width={600}
       maskClosable={false}
+      okButtonProps={{ disabled: isSuperAdmin }}
+      okText={isSuperAdmin ? '确定' : undefined}
     >
       <Form form={form} layout="vertical">
         <Row gutter={16}>
@@ -58,7 +62,11 @@ const UserFormModal: React.FC<UserFormModalProps> = ({ visible, selectedRecord, 
                 { max: 128, message: '昵称长度不能超过128个字符' },
               ]}
             >
-              <Input placeholder="请输入昵称" maxLength={128} />
+              <Input 
+                placeholder="请输入昵称" 
+                maxLength={128} 
+                disabled={isSuperAdmin}
+              />
             </Form.Item>
           </Col>
           <Col span={12}>
@@ -71,7 +79,11 @@ const UserFormModal: React.FC<UserFormModalProps> = ({ visible, selectedRecord, 
                 { max: 128, message: '邮箱长度不能超过128个字符' },
               ]}
             >
-              <Input placeholder="请输入邮箱" maxLength={128} />
+              <Input 
+                placeholder="请输入邮箱" 
+                maxLength={128} 
+                disabled={isSuperAdmin}
+              />
             </Form.Item>
           </Col>
         </Row>
@@ -79,7 +91,11 @@ const UserFormModal: React.FC<UserFormModalProps> = ({ visible, selectedRecord, 
         <Row gutter={16}>
           <Col span={12}>
             <Form.Item name="role" label="角色" rules={[{ required: true, message: '请选择角色' }]}>
-              <Select options={roleOptions} placeholder="请选择角色" />
+              <Select 
+                options={roleOptions} 
+                placeholder="请选择角色" 
+                disabled={isSuperAdmin}
+              />
             </Form.Item>
           </Col>
           <Col span={12}>
@@ -90,6 +106,7 @@ const UserFormModal: React.FC<UserFormModalProps> = ({ visible, selectedRecord, 
                   { value: 0, label: '禁用' },
                 ]}
                 placeholder="请选择状态"
+                disabled={isSuperAdmin}
               />
             </Form.Item>
           </Col>

--- a/miaocha-ui/frontend/src/pages/system/UserManagement/hooks/useTableConfig.tsx
+++ b/miaocha-ui/frontend/src/pages/system/UserManagement/hooks/useTableConfig.tsx
@@ -122,21 +122,25 @@ export const useTableConfig = ({ onEdit, onDelete, onChangePassword, onOpenModul
       key: 'action',
       fixed: 'right',
       width: 200,
-      render: (_, record) => (
-        <Space size={0}>
-          <Button type="link" onClick={() => onEdit(record)} style={{ padding: '0 8px' }}>
-            编辑
-          </Button>
-          {record.role === 'USER' && (
-            <Button type="link" onClick={() => onOpenModuleDrawer(record)} style={{ padding: '0 8px' }}>
-              授权
-            </Button>
-          )}
-          {
-            <>
-              <Button type="link" onClick={() => onChangePassword(record)} style={{ padding: '0 8px' }}>
-                改密码
+      render: (_, record) => {
+        const isSuperAdmin = record.role === 'SUPER_ADMIN';
+        
+        return (
+          <Space size={0}>
+            {!isSuperAdmin && (
+              <Button type="link" onClick={() => onEdit(record)} style={{ padding: '0 8px' }}>
+                编辑
               </Button>
+            )}
+            {record.role === 'USER' && (
+              <Button type="link" onClick={() => onOpenModuleDrawer(record)} style={{ padding: '0 8px' }}>
+                授权
+              </Button>
+            )}
+            <Button type="link" onClick={() => onChangePassword(record)} style={{ padding: '0 8px' }}>
+              改密码
+            </Button>
+            {!isSuperAdmin && (
               <Popconfirm
                 title="确定要删除此用户吗？"
                 description="此操作不可撤销"
@@ -150,10 +154,10 @@ export const useTableConfig = ({ onEdit, onDelete, onChangePassword, onOpenModul
                   删除
                 </Button>
               </Popconfirm>
-            </>
-          }
-        </Space>
-      ),
+            )}
+          </Space>
+        );
+      },
     },
   ];
 

--- a/miaocha-ui/frontend/src/pages/system/UserManagement/hooks/useUserActions.ts
+++ b/miaocha-ui/frontend/src/pages/system/UserManagement/hooks/useUserActions.ts
@@ -34,6 +34,16 @@ export const useUserActions = ({ setData, data, originalDataRef, moduleList, fet
   // 处理删除用户
   const handleDelete = async (key: string) => {
     try {
+      // 检查是否为超级管理员
+      const user = data.find(item => item.key === key);
+      if (user?.role === 'SUPER_ADMIN') {
+        handleError('超级管理员用户不能被删除', {
+          type: ErrorType.VALIDATION,
+          showType: 'message',
+        });
+        return;
+      }
+      
       await deleteUser(key);
       setData(data.filter((item) => item.key !== key));
       showSuccess('用户删除成功');
@@ -60,6 +70,15 @@ export const useUserActions = ({ setData, data, originalDataRef, moduleList, fet
       };
 
       if (selectedRecord) {
+        // 检查是否为超级管理员
+        if (selectedRecord.role === 'SUPER_ADMIN') {
+          handleError('超级管理员用户信息不能被修改', {
+            type: ErrorType.VALIDATION,
+            showType: 'message',
+          });
+          return;
+        }
+        
         // 编辑现有用户
         await updateUser({
           id: selectedRecord.key,

--- a/miaocha-ui/frontend/vite.config.ts
+++ b/miaocha-ui/frontend/vite.config.ts
@@ -113,8 +113,8 @@ export default defineConfig({
     open: true,
     proxy: {
       '/api': {
-        // target: 'http://10.254.133.210:32088',
-        target: 'https://miaocha.hinadt.com', // 生产环境
+        target: 'http://10.254.133.210:32088',
+        // target: 'https://miaocha.hinadt.com', // 生产环境
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
Closes #38

## 变更的目的是什么

 1.超级管理员当前用户编辑可修改，虽提交后不成功，但交互不友好，需隐藏编辑按钮；
2.管理员角色，不可修改非当前管理员的用户信息；

## 简短的更新日志

<!-- 请替换下面的XX为实际内容，并删除这个注释 -->
XX

## 验证这一变化

<!-- 请替换下面的XXXX为实际内容，并删除这个注释 -->
XXXX

<!-- 请在每个checkbox前打勾 [x] 来确认已完成，并删除这个注释 -->
请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [ ] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [ ] 确保编译通过，集成测试通过；
