### PR TITLE
[ISSUE #85] 修复带注释的 SELECT 语句识别错误问题

### DIFF
--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/TableValidationServiceImpl.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/TableValidationServiceImpl.java
@@ -578,7 +578,7 @@ public class TableValidationServiceImpl implements TableValidationService {
                 }
             }
 
-            // 如果在字符串或标识符内，直接添��字符
+            // 如果在字符串或标识符内，直接添加字符
             if (inSingleQuotes || inDoubleQuotes || inBackticks) {
                 if (!inLineComment && !inBlockComment) {
                     result.append(current);

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/TableValidationServiceImpl.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/TableValidationServiceImpl.java
@@ -533,7 +533,36 @@ public class TableValidationServiceImpl implements TableValidationService {
         if (sql == null || sql.trim().isEmpty()) {
             return false;
         }
-        return SELECT_PATTERN.matcher(sql.trim()).find();
+        // 先去除前置注释和空白行
+        String cleaned = removeLeadingCommentsAndBlanks(sql);
+        return SELECT_PATTERN.matcher(cleaned).find();
+    }
+
+    /** 去除SQL前的注释和空白行 */
+    private String removeLeadingCommentsAndBlanks(String sql) {
+        String[] lines = sql.split("\\r?\\n");
+        StringBuilder sb = new StringBuilder();
+        boolean inBlockComment = false;
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (!inBlockComment) {
+                if (trimmed.startsWith("--") || trimmed.isEmpty()) {
+                    continue;
+                }
+                if (trimmed.startsWith("/*")) {
+                    inBlockComment = true;
+                    continue;
+                }
+            }
+            if (inBlockComment) {
+                if (trimmed.endsWith("*/")) {
+                    inBlockComment = false;
+                }
+                continue;
+            }
+            sb.append(trimmed).append(" ");
+        }
+        return sb.toString().trim();
     }
 
     @Override

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/TableValidationServiceImpl.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/TableValidationServiceImpl.java
@@ -43,17 +43,7 @@ public class TableValidationServiceImpl implements TableValidationService {
                     "^\\s*CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?",
                     Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
-    /** 字段定义的正则表达式 - 匹配字段名、类型等 */
-    private static final Pattern FIELD_DEFINITION_PATTERN =
-            Pattern.compile(
-                    "\\s*(?:`([^`]+)`|([a-zA-Z_][a-zA-Z0-9_]*))\\s+([a-zA-Z0-9_()\\s,]+?)(?:,|\\s*\\)|$)",
-                    Pattern.CASE_INSENSITIVE);
-
     // ==================== SQL 语句处理相关常量 ====================
-
-    /** SELECT 语句检测正则 */
-    private static final Pattern SELECT_PATTERN =
-            Pattern.compile("^\\s*SELECT\\s+", Pattern.CASE_INSENSITIVE);
 
     /** LIMIT 子句检测正则 */
     private static final Pattern LIMIT_PATTERN =
@@ -533,36 +523,151 @@ public class TableValidationServiceImpl implements TableValidationService {
         if (sql == null || sql.trim().isEmpty()) {
             return false;
         }
-        // 先去除前置注释和空白行
-        String cleaned = removeLeadingCommentsAndBlanks(sql);
-        return SELECT_PATTERN.matcher(cleaned).find();
+
+        // 使用更完善的注释清理逻辑
+        String cleaned = removeCommentsAndWhitespace(sql);
+
+        // 使用更宽松的 SELECT 语句检测
+        return isSelectStatementInternal(cleaned);
     }
 
-    /** 去除SQL前的注释和空白行 */
-    private String removeLeadingCommentsAndBlanks(String sql) {
-        String[] lines = sql.split("\\r?\\n");
-        StringBuilder sb = new StringBuilder();
-        boolean inBlockComment = false;
-        for (String line : lines) {
-            String trimmed = line.trim();
-            if (!inBlockComment) {
-                if (trimmed.startsWith("--") || trimmed.isEmpty()) {
-                    continue;
-                }
-                if (trimmed.startsWith("/*")) {
-                    inBlockComment = true;
-                    continue;
-                }
-            }
-            if (inBlockComment) {
-                if (trimmed.endsWith("*/")) {
-                    inBlockComment = false;
+    /** 完善的 SQL 注释和空白字符清理逻辑 正确处理： 1. 单行注释 (--) 2. 块注释 (斜杠星号 星号斜杠) 3. 字符串字面量中的注释符号 4. 转义字符 5. 嵌套注释 */
+    private String removeCommentsAndWhitespace(String sql) {
+        if (sql == null || sql.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder result = new StringBuilder();
+        char[] chars = sql.toCharArray();
+        int length = chars.length;
+
+        boolean inSingleQuotes = false; // 单引号字符串
+        boolean inDoubleQuotes = false; // 双引号字符串
+        boolean inBackticks = false; // 反引号标识符
+        boolean inLineComment = false; // 单行注释
+        boolean inBlockComment = false; // 块注释
+        int blockCommentDepth = 0; // 嵌套块注释深度
+
+        for (int i = 0; i < length; i++) {
+            char current = chars[i];
+            char next = (i + 1 < length) ? chars[i + 1] : '\0';
+            char prev = (i > 0) ? chars[i - 1] : '\0';
+
+            // 处理转义字符
+            if (prev == '\\' && (inSingleQuotes || inDoubleQuotes)) {
+                if (!inLineComment && !inBlockComment) {
+                    result.append(current);
                 }
                 continue;
             }
-            sb.append(trimmed).append(" ");
+
+            // 处理字符串和标识符边界
+            if (!inLineComment && !inBlockComment) {
+                if (current == '\'' && !inDoubleQuotes && !inBackticks) {
+                    inSingleQuotes = !inSingleQuotes;
+                    result.append(current);
+                    continue;
+                } else if (current == '"' && !inSingleQuotes && !inBackticks) {
+                    inDoubleQuotes = !inDoubleQuotes;
+                    result.append(current);
+                    continue;
+                } else if (current == '`' && !inSingleQuotes && !inDoubleQuotes) {
+                    inBackticks = !inBackticks;
+                    result.append(current);
+                    continue;
+                }
+            }
+
+            // 如果在字符串或标识符内，直接添��字符
+            if (inSingleQuotes || inDoubleQuotes || inBackticks) {
+                if (!inLineComment && !inBlockComment) {
+                    result.append(current);
+                }
+                continue;
+            }
+
+            // 处理注释开始
+            if (!inLineComment && !inBlockComment) {
+                // 检测单行注释
+                if (current == '-' && next == '-') {
+                    inLineComment = true;
+                    i++; // 跳过下一个 '-'
+                    continue;
+                }
+
+                // 检测块注释开始
+                if (current == '/' && next == '*') {
+                    inBlockComment = true;
+                    blockCommentDepth = 1;
+                    i++; // 跳过下一个 '*'
+                    continue;
+                }
+            }
+
+            // 处理块注释中的嵌套
+            if (inBlockComment) {
+                if (current == '/' && next == '*') {
+                    blockCommentDepth++;
+                    i++; // 跳过下一个 '*'
+                    continue;
+                } else if (current == '*' && next == '/') {
+                    blockCommentDepth--;
+                    if (blockCommentDepth == 0) {
+                        inBlockComment = false;
+                    }
+                    i++; // 跳过下一个 '/'
+                    continue;
+                }
+                // 在块注释中，跳过所有字符
+                continue;
+            }
+
+            // 处理单行注释结束
+            if (inLineComment) {
+                if (current == '\n' || current == '\r') {
+                    inLineComment = false;
+                    // 保留换行符用于后续处理
+                    result.append(' ');
+                }
+                continue;
+            }
+
+            // 正常字符处理：标准化空白字符
+            if (Character.isWhitespace(current)) {
+                // 将连续的空白字符压缩为单个空格
+                if (result.length() > 0 && result.charAt(result.length() - 1) != ' ') {
+                    result.append(' ');
+                }
+            } else {
+                result.append(current);
+            }
         }
-        return sb.toString().trim();
+
+        return result.toString().trim();
+    }
+
+    /**
+     * 更宽松的 SELECT 语句检测逻辑 支持检测： 1. 标准 SELECT 语句 2. WITH 子句开头的 CTE 查询 3. 括号包围的 SELECT 语句 4. 复杂的嵌套查询结构
+     */
+    private boolean isSelectStatementInternal(String cleanedSql) {
+        if (cleanedSql == null || cleanedSql.isEmpty()) {
+            return false;
+        }
+
+        String upperSql = cleanedSql.toUpperCase().trim();
+
+        // 移除开头的括号
+        while (upperSql.startsWith("(")) {
+            upperSql = upperSql.substring(1).trim();
+        }
+
+        // 检测各种 SELECT 语句模式
+        return upperSql.startsWith("SELECT ")
+                || upperSql.startsWith("WITH ")
+                || // CTE 查询
+                upperSql.startsWith("(SELECT ")
+                || // 括号包围的查询
+                upperSql.matches("^\\s*\\(\\s*WITH\\s+.*"); // 括号包围的 CTE
     }
 
     @Override

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/UserServiceImpl.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/impl/UserServiceImpl.java
@@ -125,7 +125,7 @@ public class UserServiceImpl implements UserService {
         } catch (Exception e) {
             // 处理其他异常
             log.error("Error during token refresh: {}", e.getMessage());
-            throw new BusinessException(ErrorCode.INVALID_TOKEN, "无�的刷新令牌");
+            throw new BusinessException(ErrorCode.INVALID_TOKEN, "无效的刷新令牌");
         }
     }
 

--- a/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/TableValidationServiceImplTest.java
+++ b/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/TableValidationServiceImplTest.java
@@ -718,7 +718,7 @@ class TableValidationServiceImplTest {
                     "DELETE FROM users WHERE id = 1",
                     "CREATE TABLE test_table (id INT, name VARCHAR(50))"
                 })
-        @DisplayName("LIMIT处理 - 非SELECT语句保���不变")
+        @DisplayName("LIMIT处理 - 非SELECT语句保持不变")
         void testProcessSqlWithLimit_NonSelectStatements(String sql) {
             String result = tableValidationService.processSqlWithLimit(sql);
 
@@ -726,7 +726,7 @@ class TableValidationServiceImplTest {
         }
 
         @Test
-        @DisplayName("LIMIT处理 - 已有��法LIMIT保持不变")
+        @DisplayName("LIMIT处理 - 已有合法LIMIT保持不变")
         void testProcessSqlWithLimit_ExistingValidLimit() {
             String sqlWithLimit = "SELECT * FROM users LIMIT 500";
             String result = tableValidationService.processSqlWithLimit(sqlWithLimit);

--- a/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/TableValidationServiceImplTest.java
+++ b/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/TableValidationServiceImplTest.java
@@ -797,5 +797,30 @@ class TableValidationServiceImplTest {
             tableNames = tableValidationService.extractTableNames(null);
             assertTrue(tableNames.isEmpty());
         }
+
+        @Test
+        @DisplayName("带注释和空行的复杂SELECT语句检测")
+        void testIsSelectStatement_WithCommentsAndBlanks() {
+            String sql =
+                    """
+                -- 用于模板中携带最后一条message和查询时间范围
+
+                SELECT
+                    message[\"msg\"] AS \"raw_message\",
+                    CONCAT(
+                        DATE_FORMAT(NOW() - INTERVAL 10 minute, '%Y-%m-%d %H:%i:%S'),
+                        ' 至 ',
+                        DATE_FORMAT(NOW(), '%Y-%m-%d %H:%i:%S')
+                    ) AS raw_time_range,
+                    1 as \"value\"
+                FROM log_db.log_xunxin_pro
+                WHERE
+                    log_time >= NOW() - INTERVAL 10 MINUTE
+                    and message[\"msg\"] LIKE '%集群,批次记录新增失败%'
+                ORDER BY log_time DESC
+                LIMIT 1
+                """;
+            assertTrue(tableValidationService.isSelectStatement(sql), "带注释和空行的复杂SELECT语句应该被识别");
+        }
     }
 }


### PR DESCRIPTION
Closes #85


## 变更的目的是什么

修复当执行 SELECT 语句时前面带有 ' -- ' 这样的注释时，无法识别为 SELECT 语句从而导致的普通用户执行 SELECT 语句没有权限问题。


## 简短的更新日志

正则识别加强，识别 SELECT 语句时，预先清楚SQL语句前面的注释



<!-- 请在每个checkbox前打勾 [x] 来确认已完成，并删除这个注释 -->
请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；
