### PR TITLE
[ISSUE #96] 修复 where sql 查询时, variant  子字段数值比较查询不准确问题

### DIFF
--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/sql/converter/LogSearchDTOConverter.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/sql/converter/LogSearchDTOConverter.java
@@ -92,7 +92,7 @@ public class LogSearchDTOConverter {
         }
 
         // 应用转换链：先进行数字运算符转换，再进行variant字段转换
-        List<String> convertedClauses = new ArrayList<>();
+        List<String> convertedClauses = new ArrayList<>(whereClauses.size());
         for (String clause : whereClauses) {
             String processedClause = clause;
 

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/sql/converter/LogSearchDTOConverter.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/sql/converter/LogSearchDTOConverter.java
@@ -2,6 +2,7 @@ package com.hinadt.miaocha.application.service.sql.converter;
 
 import com.hinadt.miaocha.domain.dto.logsearch.LogSearchDTO;
 import com.hinadt.miaocha.domain.dto.logsearch.LogSearchDTODecorator;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,10 +16,14 @@ import org.springframework.stereotype.Service;
 public class LogSearchDTOConverter {
 
     private final VariantFieldConverter variantFieldConverter;
+    private final NumericOperatorConverter numericOperatorConverter;
 
     @Autowired
-    public LogSearchDTOConverter(VariantFieldConverter variantFieldConverter) {
+    public LogSearchDTOConverter(
+            VariantFieldConverter variantFieldConverter,
+            NumericOperatorConverter numericOperatorConverter) {
         this.variantFieldConverter = variantFieldConverter;
+        this.numericOperatorConverter = numericOperatorConverter;
     }
 
     /**
@@ -75,14 +80,36 @@ public class LogSearchDTOConverter {
             return whereClauses;
         }
 
-        // 检查是否需要转换
-        boolean needsConversion = whereClauses.stream().anyMatch(this::containsVariantFields);
+        // 检查是否需要variant字段转换或数字运算符转换
+        boolean needsVariantConversion =
+                whereClauses.stream().anyMatch(this::containsVariantFields);
+        boolean needsNumericConversion =
+                whereClauses.stream()
+                        .anyMatch(numericOperatorConverter::needsNumericOperatorConversion);
 
-        if (!needsConversion) {
+        if (!needsVariantConversion && !needsNumericConversion) {
             return whereClauses; // 返回原始对象，避免不必要的复制
         }
 
-        return variantFieldConverter.convertWhereClauses(whereClauses);
+        // 应用转换链：先进行数字运算符转换，再进行variant字段转换
+        List<String> convertedClauses = new ArrayList<>();
+        for (String clause : whereClauses) {
+            String processedClause = clause;
+
+            // 1. 先进行数字运算符转换
+            if (numericOperatorConverter.needsNumericOperatorConversion(processedClause)) {
+                processedClause = numericOperatorConverter.convertNumericOperators(processedClause);
+            }
+
+            // 2. 再进行variant字段转换
+            if (containsVariantFields(processedClause)) {
+                processedClause = variantFieldConverter.convertWhereClause(processedClause);
+            }
+
+            convertedClauses.add(processedClause);
+        }
+
+        return convertedClauses;
     }
 
     /**

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/sql/converter/NumericOperatorConverter.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/sql/converter/NumericOperatorConverter.java
@@ -1,0 +1,216 @@
+package com.hinadt.miaocha.application.service.sql.converter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+/**
+ * 数字运算符转换器
+ *
+ * <p>用于解决Doris数据库在处理variant字段与数字比较时的缺陷。 通过在比较运算符后的数字添加"*1"来规避问题。
+ *
+ * <p>转换规则： - message.marker.duration > 100 -> message.marker.duration > 100*1 -
+ * message.marker.duration >= 200 -> message.marker.duration >= 200*1 - message.marker.duration <
+ * 300 -> message.marker.duration < 300*1 - message.marker.duration <= 400 ->
+ * message.marker.duration <= 400*1 - message.marker.duration = 500 -> message.marker.duration =
+ * 500*1 - message.marker.duration != 600 -> message.marker.duration != 600*1
+ *
+ * <p>注意事项： - 只处理variant字段（包含点语法的字段）与数字的比较 - 不处理引号内的内容 - 支持整数和小数 - 支持负数
+ */
+@Component
+public class NumericOperatorConverter {
+
+    /** 用于匹配variant字段与数字比较的正则表达式 匹配模式：字段名 运算符 数字 例如：message.data.count > 100 */
+    private static final Pattern VARIANT_NUMERIC_PATTERN =
+            Pattern.compile(
+                    "(\\b[a-zA-Z_][a-zA-Z0-9_]*\\.[a-zA-Z0-9_.]+)(\\s*(?:>=|<=|!=|>|<|=)\\s*)(-?\\d+(?:\\.\\d+)?)(?![*/+\\-eE]|\\d)");
+
+    // 用于检测字符串是否在引号内的辅助模式
+    private static final Pattern QUOTE_PATTERN = Pattern.compile("['\"].*?['\"]|['\"][^'\"]*$");
+
+    /**
+     * 转换WHERE条件中的数字运算符
+     *
+     * @param whereClause WHERE条件子句
+     * @return 转换后的WHERE条件
+     */
+    public String convertNumericOperators(String whereClause) {
+        if (whereClause == null || whereClause.trim().isEmpty()) {
+            return whereClause;
+        }
+
+        return convertNumericOperatorsSafely(whereClause);
+    }
+
+    /**
+     * 安全地转换数字运算符，正确处理引号内的内容
+     *
+     * @param input 输入字符串
+     * @return 转换后的字符串
+     */
+    private String convertNumericOperatorsSafely(String input) {
+        // 首先找出所有引号内的内容位置，避免在引号内进行转换
+        StringBuilder result = new StringBuilder();
+        int lastEnd = 0;
+
+        Matcher quoteMatcher = QUOTE_PATTERN.matcher(input);
+
+        while (quoteMatcher.find()) {
+            // 处理引号前的部分
+            String beforeQuote = input.substring(lastEnd, quoteMatcher.start());
+            result.append(convertInNonQuotedText(beforeQuote));
+
+            // 直接添加引号内的内容，不进行转换
+            result.append(quoteMatcher.group());
+
+            lastEnd = quoteMatcher.end();
+        }
+
+        // 处理最后一部分（如果有的话）
+        if (lastEnd < input.length()) {
+            String remaining = input.substring(lastEnd);
+            result.append(convertInNonQuotedText(remaining));
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * 在非引号文本中进行转换
+     *
+     * @param text 非引号文本
+     * @return 转换后的文本
+     */
+    private String convertInNonQuotedText(String text) {
+        if (text == null || text.trim().isEmpty()) {
+            return text;
+        }
+
+        Matcher matcher = VARIANT_NUMERIC_PATTERN.matcher(text);
+        StringBuffer sb = new StringBuffer();
+
+        while (matcher.find()) {
+            String fieldName = matcher.group(1);
+            String operator = matcher.group(2);
+            String number = matcher.group(3);
+
+            // 验证字段名是否确实是variant字段（包含点语法）
+            if (isVariantField(fieldName)) {
+                // 构建替换字符串：字段名 运算符 数字*1（保留原有空格）
+                String replacement = fieldName + operator + number + "*1";
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+            } else {
+                // 不是variant字段，保持原样
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group()));
+            }
+        }
+
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * 检查字段是否是variant字段（包含点语法）
+     *
+     * @param fieldName 字段名
+     * @return 是否是variant字段
+     */
+    private boolean isVariantField(String fieldName) {
+        return fieldName != null && fieldName.contains(".") && isValidVariantFieldName(fieldName);
+    }
+
+    /**
+     * 验证是否是有效的variant字段名
+     *
+     * @param fieldName 字段名
+     * @return 是否有效
+     */
+    private boolean isValidVariantFieldName(String fieldName) {
+        if (fieldName == null || fieldName.trim().isEmpty()) {
+            return false;
+        }
+
+        String[] parts = fieldName.split("\\.");
+        if (parts.length < 2) {
+            return false;
+        }
+
+        // 检查根字段（第一个部分）必须是有效的标识符
+        if (!isValidRootIdentifier(parts[0])) {
+            return false;
+        }
+
+        // 检查子字段（后续部分）
+        for (int i = 1; i < parts.length; i++) {
+            if (!isValidSubIdentifier(parts[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 检查是否是有效的根字段标识符
+     *
+     * @param identifier 标识符
+     * @return 是否有效
+     */
+    private boolean isValidRootIdentifier(String identifier) {
+        if (identifier == null || identifier.isEmpty()) {
+            return false;
+        }
+
+        // 第一个字符必须是字母或下划线
+        char firstChar = identifier.charAt(0);
+        if (!Character.isLetter(firstChar) && firstChar != '_') {
+            return false;
+        }
+
+        // 后续字符可以是字母、数字或下划线
+        for (int i = 1; i < identifier.length(); i++) {
+            char c = identifier.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != '_') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 检查是否是有效的子字段标识符
+     *
+     * @param identifier 标识符
+     * @return 是否有效
+     */
+    private boolean isValidSubIdentifier(String identifier) {
+        if (identifier == null || identifier.isEmpty()) {
+            return false;
+        }
+
+        // 子字段可以以数字开头
+        for (char c : identifier.toCharArray()) {
+            if (!Character.isLetterOrDigit(c) && c != '_') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 检查WHERE条件是否需要数字运算符转换
+     *
+     * @param whereClause WHERE条件
+     * @return 是否需要转换
+     */
+    public boolean needsNumericOperatorConversion(String whereClause) {
+        if (whereClause == null || whereClause.trim().isEmpty()) {
+            return false;
+        }
+
+        // 简单检查是否包含variant字段和数字比较的模式
+        return VARIANT_NUMERIC_PATTERN.matcher(whereClause).find();
+    }
+}

--- a/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/logsearch/LogSearchDTOConverterTest.java
+++ b/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/logsearch/LogSearchDTOConverterTest.java
@@ -3,6 +3,7 @@ package com.hinadt.miaocha.mock.service.logsearch;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.hinadt.miaocha.application.service.sql.converter.LogSearchDTOConverter;
+import com.hinadt.miaocha.application.service.sql.converter.NumericOperatorConverter;
 import com.hinadt.miaocha.application.service.sql.converter.VariantFieldConverter;
 import com.hinadt.miaocha.domain.dto.logsearch.LogSearchDTO;
 import com.hinadt.miaocha.domain.dto.logsearch.LogSearchDTODecorator;
@@ -33,9 +34,10 @@ class LogSearchDTOConverterTest {
 
     @BeforeEach
     void setUp() {
-        // 使用真实的VariantFieldConverter，不使用Mock
+        // 使用真实的VariantFieldConverter和NumericOperatorConverter，不使用Mock
         variantFieldConverter = new VariantFieldConverter();
-        converter = new LogSearchDTOConverter(variantFieldConverter);
+        NumericOperatorConverter numericOperatorConverter = new NumericOperatorConverter();
+        converter = new LogSearchDTOConverter(variantFieldConverter, numericOperatorConverter);
     }
 
     // ==================== 基本转换测试 ====================

--- a/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/sql/builder/LogSqlBuilderTest.java
+++ b/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/sql/builder/LogSqlBuilderTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import com.hinadt.miaocha.application.service.impl.logsearch.validator.QueryConfigValidationService;
 import com.hinadt.miaocha.application.service.sql.builder.*;
 import com.hinadt.miaocha.application.service.sql.converter.LogSearchDTOConverter;
+import com.hinadt.miaocha.application.service.sql.converter.NumericOperatorConverter;
 import com.hinadt.miaocha.application.service.sql.converter.VariantFieldConverter;
 import com.hinadt.miaocha.domain.dto.logsearch.LogSearchDTO;
 import com.hinadt.miaocha.domain.dto.logsearch.LogSearchDTODecorator;
@@ -73,7 +74,8 @@ class LogSqlBuilderTest {
 
         // 创建DTO转换器用于测试
         VariantFieldConverter variantFieldConverter = new VariantFieldConverter();
-        dtoConverter = new LogSearchDTOConverter(variantFieldConverter);
+        NumericOperatorConverter numericOperatorConverter = new NumericOperatorConverter();
+        dtoConverter = new LogSearchDTOConverter(variantFieldConverter, numericOperatorConverter);
     }
 
     @Nested

--- a/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/sql/converter/NumericOperatorConverterTest.java
+++ b/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/sql/converter/NumericOperatorConverterTest.java
@@ -1,0 +1,155 @@
+package com.hinadt.miaocha.mock.service.sql.converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hinadt.miaocha.application.service.sql.converter.NumericOperatorConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** NumericOperatorConverter单元测试 */
+class NumericOperatorConverterTest {
+
+    private NumericOperatorConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new NumericOperatorConverter();
+    }
+
+    @Test
+    void testBasicConversion() {
+        // 基本转换
+        assertEquals(
+                "message.data.count > 100*1",
+                converter.convertNumericOperators("message.data.count > 100"));
+
+        // 不同运算符
+        assertEquals(
+                "message.data.value >= 50*1",
+                converter.convertNumericOperators("message.data.value >= 50"));
+        assertEquals(
+                "message.data.size < 1024*1",
+                converter.convertNumericOperators("message.data.size < 1024"));
+        assertEquals(
+                "message.data.code = 404*1",
+                converter.convertNumericOperators("message.data.code = 404"));
+    }
+
+    @Test
+    void testNumberFormats() {
+        // 小数
+        assertEquals(
+                "message.data.rate > 3.14*1",
+                converter.convertNumericOperators("message.data.rate > 3.14"));
+
+        // 负数
+        assertEquals(
+                "message.data.temp < -10*1",
+                converter.convertNumericOperators("message.data.temp < -10"));
+
+        // 负小数
+        assertEquals(
+                "message.data.offset <= -25.5*1",
+                converter.convertNumericOperators("message.data.offset <= -25.5"));
+
+        // 科学计数法（不应转换）
+        assertEquals(
+                "message.data.value > 1e5",
+                converter.convertNumericOperators("message.data.value > 1e5"));
+    }
+
+    @Test
+    void testNonVariantFields() {
+        // 普通字段不转换
+        assertEquals("count > 100", converter.convertNumericOperators("count > 100"));
+        assertEquals("level = 5", converter.convertNumericOperators("level = 5"));
+    }
+
+    @Test
+    void testQuotedContent() {
+        // 引号内不转换
+        assertEquals(
+                "message.text = 'count > 100'",
+                converter.convertNumericOperators("message.text = 'count > 100'"));
+        assertEquals(
+                "message.sql = \"value >= 50\"",
+                converter.convertNumericOperators("message.sql = \"value >= 50\""));
+    }
+
+    @Test
+    void testEdgeCases() {
+        // 空值
+        assertNull(converter.convertNumericOperators(null));
+        assertEquals("", converter.convertNumericOperators(""));
+        assertEquals("   ", converter.convertNumericOperators("   "));
+
+        // 已有运算符
+        assertEquals(
+                "message.data.value > 100*2",
+                converter.convertNumericOperators("message.data.value > 100*2"));
+        assertEquals(
+                "message.data.value > 100+1",
+                converter.convertNumericOperators("message.data.value > 100+1"));
+
+        // 多条件
+        assertEquals(
+                "message.data.count > 100*1 AND message.data.size < 200*1",
+                converter.convertNumericOperators(
+                        "message.data.count > 100 AND message.data.size < 200"));
+
+        // LIKE语句中的引号内容（不应转换）
+        assertEquals(
+                "message.msg like 'a > 100'",
+                converter.convertNumericOperators("message.msg like 'a > 100'"));
+
+        // 混合场景：LIKE + 正常比较
+        assertEquals(
+                "message.data.count > 50*1 AND message.msg like 'value > 100'",
+                converter.convertNumericOperators(
+                        "message.data.count > 50 AND message.msg like 'value > 100'"));
+    }
+
+    @Test
+    void testComplexScenarios() {
+        // 复杂嵌套场景：引号内包含复杂表达式，引号外有正常比较
+        assertEquals(
+                "( message.msg like 'marker.duration >= 100 and marker.a < 100' and message.aaa <"
+                        + " 200.0*1 ) or mess.a100.c100 < 20*1",
+                converter.convertNumericOperators(
+                        "( message.msg like 'marker.duration >= 100 and marker.a < 100' and"
+                                + " message.aaa < 200.0 ) or mess.a100.c100 < 20"));
+
+        // 多层嵌套括号和复杂逻辑
+        assertEquals(
+                "((message.data.value > 100*1 AND message.info.count <= 50*1) OR"
+                        + " (message.status.code = 200*1)) AND message.msg like 'error >= 500'",
+                converter.convertNumericOperators(
+                        "((message.data.value > 100 AND message.info.count <= 50) OR"
+                            + " (message.status.code = 200)) AND message.msg like 'error >= 500'"));
+
+        // 混合引号类型（单引号和双引号）
+        assertEquals(
+                "message.data.score > 85*1 AND message.msg like \"value >= 100\" AND"
+                        + " message.info.level < 3*1",
+                converter.convertNumericOperators(
+                        "message.data.score > 85 AND message.msg like \"value >= 100\" AND"
+                                + " message.info.level < 3"));
+
+        // 包含IN语句和复杂条件
+        assertEquals(
+                "message.data.type IN ('A', 'B', 'C') AND message.data.value > 100*1 AND"
+                        + " message.msg like 'status >= 200'",
+                converter.convertNumericOperators(
+                        "message.data.type IN ('A', 'B', 'C') AND message.data.value > 100 AND"
+                                + " message.msg like 'status >= 200'"));
+
+        // 极端复杂场景：多种运算符、嵌套引号、科学计数法
+        assertEquals(
+                "(message.data.count >= 1000*1 OR message.info.size <= 2.5*1) AND message.log like"
+                        + " 'value = 1e5 and count > 999' AND message.stats.ratio != 0.75*1",
+                converter.convertNumericOperators(
+                        "(message.data.count >= 1000 OR message.info.size <= 2.5) AND message.log"
+                                + " like 'value = 1e5 and count > 999' AND message.stats.ratio !="
+                                + " 0.75"));
+    }
+}


### PR DESCRIPTION
Closes #96

## 变更的目的是什么

修复 whereSQL 查询时，variant 子字段数值比较的时候不准确

## 简短的更新日志

<!-- 请替换下面的XX为实际内容，并删除这个注释 -->
XX

## 验证这一变化

<!-- 请替换下面的XXXX为实际内容，并删除这个注释 -->
XXXX

<!-- 请在每个checkbox前打勾 [x] 来确认已完成，并删除这个注释 -->
请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；
