### PR TITLE
[ISSUE #127] 优化 Logstash 启动命令, 去除 nohup 输出日志, 依赖 Logstash 自有日志机制

### DIFF
--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/logstash/LogTailServiceImpl.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/logstash/LogTailServiceImpl.java
@@ -107,7 +107,7 @@ public class LogTailServiceImpl implements LogTailService {
 
         // 构建日志文件路径
         String deployPath = deployPathManager.getInstanceDeployPath(logstashMachineId);
-        String logFilePath = LogstashPathUtils.buildLogFilePath(deployPath, logstashMachineId);
+        String logFilePath = LogstashPathUtils.buildLogFilePath(deployPath);
 
         // 简化命令，测试基本的tail功能
         String tailCommand = String.format("tail -n %d -f %s", tailLines, logFilePath);

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/logstash/command/StartProcessCommand.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/logstash/command/StartProcessCommand.java
@@ -61,12 +61,10 @@ public class StartProcessCommand extends AbstractLogstashCommand {
     protected boolean doExecute(MachineInfo machineInfo) {
         try {
             String processDir = getProcessDirectory();
-            String configDir = LogstashPathUtils.buildConfigDirPath(processDir);
-            String logDir = LogstashPathUtils.buildLogDirPath(processDir);
             String configPath =
                     LogstashPathUtils.buildConfigFilePath(processDir, logstashMachineId);
             String pidFile = LogstashPathUtils.buildPidFilePath(processDir, logstashMachineId);
-            String logFile = LogstashPathUtils.buildLogFilePath(processDir, logstashMachineId);
+            String logDir = LogstashPathUtils.buildLogDirPath(processDir);
 
             // 确保日志目录存在
             String createLogDirCommand = String.format("mkdir -p %s", logDir);
@@ -81,12 +79,12 @@ public class StartProcessCommand extends AbstractLogstashCommand {
             String scriptContent =
                     String.format(
                             "#!/bin/bash\n"
-                                + "cd %s\n"
-                                + "nohup ./bin/logstash -f %s --path.logs %s --path.data %s/data"
-                                + " --log.level info --config.reload.automatic > %s 2>&1 </dev/null"
-                                + " & \n"
-                                + "echo $! > %s\n",
-                            processDir, configPath, logDir, processDir, logFile, pidFile);
+                                    + "cd %s\n"
+                                    + "nohup ./bin/logstash -f %s "
+                                    + " --log.level info --config.reload.automatic > /dev/null 2>&1"
+                                    + " & \n"
+                                    + "echo $! > %s\n",
+                            processDir, configPath, pidFile);
 
             // 将脚本写入临时文件
             String tempScript =

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/logstash/command/VerifyProcessCommand.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/logstash/command/VerifyProcessCommand.java
@@ -33,9 +33,8 @@ public class VerifyProcessCommand extends AbstractLogstashCommand {
     protected boolean doExecute(MachineInfo machineInfo) {
         try {
             String processDir = getProcessDirectory();
-            String logDir = LogstashPathUtils.buildLogDirPath(processDir);
             String pidFile = LogstashPathUtils.buildPidFilePath(processDir, logstashMachineId);
-            String logFile = LogstashPathUtils.buildLogFilePath(processDir, logstashMachineId);
+            String logFile = LogstashPathUtils.buildLogFilePath(processDir);
 
             // 尝试多次验证，最多尝试5次，每次间隔3秒
             for (int attempt = 1; attempt <= 5; attempt++) {

--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/logstash/path/LogstashPathUtils.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/logstash/path/LogstashPathUtils.java
@@ -7,11 +7,10 @@ public class LogstashPathUtils {
      * 构建日志文件路径
      *
      * @param deployPath 部署路径
-     * @param logstashMachineId Logstash实例ID
      * @return 日志文件完整路径
      */
-    public static String buildLogFilePath(String deployPath, Long logstashMachineId) {
-        return deployPath + "/logs/logstash-" + logstashMachineId + ".log";
+    public static String buildLogFilePath(String deployPath) {
+        return deployPath + "/logs/logstash-plain.log";
     }
 
     /**


### PR DESCRIPTION
Closes #127

## 变更的目的是什么

优化 Logstash 启动命令, 使用 nohup 强行输出不会滚动的 logstash-%d.log 日志。
这种日志不会滚动存储，会一直膨胀变大。

## 简短的更新日志

<!-- 请替换下面的XX为实际内容，并删除这个注释 -->
XX

## 验证这一变化

<!-- 请替换下面的XXXX为实际内容，并删除这个注释 -->
XXXX

<!-- 请在每个checkbox前打勾 [x] 来确认已完成，并删除这个注释 -->
请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；
