### PR TITLE
[ISSUE #139] 修复日志主界面 where sql 查询结果 or 关键字不准确

### DIFF
--- a/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/sql/builder/WhereConditionBuilder.java
+++ b/miaocha-server/src/main/java/com/hinadt/miaocha/application/service/sql/builder/WhereConditionBuilder.java
@@ -5,7 +5,6 @@ import com.hinadt.miaocha.common.exception.ErrorCode;
 import com.hinadt.miaocha.domain.dto.logsearch.LogSearchDTO;
 import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -50,19 +49,13 @@ public class WhereConditionBuilder {
                         .filter(StringUtils::isNotBlank)
                         .map(String::trim)
                         .map(this::validateAndSanitizeCondition)
-                        .collect(Collectors.toList());
+                        .map(c -> "(" + c + ")") // 关键：每个条件都加括号
+                        .toList();
 
         if (validConditions.isEmpty()) {
             return "";
         }
-
-        // 单个条件：直接返回，不添加外层括号
-        if (validConditions.size() == 1) {
-            return validConditions.get(0);
-        }
-
-        // 多个条件：使用AND连接，并添加外层括号
-        return validConditions.stream().collect(Collectors.joining(" AND ", "(", ")"));
+        return String.join(" AND ", validConditions);
     }
 
     /**

--- a/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/sql/builder/LogSqlBuilderTest.java
+++ b/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/sql/builder/LogSqlBuilderTest.java
@@ -371,7 +371,7 @@ class LogSqlBuilderTest {
             String expectedSql =
                     "SELECT TOPN(level, 5) AS 'level', count(*) AS 'total' FROM (SELECT * FROM"
                         + " test_logs WHERE log_time >= '2024-01-01 00:00:00.000' AND log_time <"
-                        + " '2024-01-01 01:00:00.000' AND (message['level'] = 'ERROR' AND host ="
+                        + " '2024-01-01 01:00:00.000' AND (message['level'] = 'ERROR') AND (host ="
                         + " 'server1') ORDER BY log_time DESC LIMIT 1000 OFFSET 0) AS sub_query";
 
             assertNotNull(result, "SQL不应为null");
@@ -407,8 +407,8 @@ class LogSqlBuilderTest {
                     "SELECT FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(log_time) / 7200) * 7200) AS"
                         + " log_time_, COUNT(*) AS count FROM test_logs WHERE log_time >="
                         + " '2024-01-01 00:00:00.000' AND log_time < '2024-01-01 01:00:00.000' AND"
-                        + " (request['headers']['authorization'] IS NOT NULL AND"
-                        + " response['data']['user']['id'] = '12345') GROUP BY"
+                        + " (request['headers']['authorization'] IS NOT NULL) AND"
+                        + " (response['data']['user']['id'] = '12345') GROUP BY"
                         + " FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(log_time) / 7200) * 7200) ORDER BY"
                         + " log_time_ ASC";
 

--- a/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/sql/builder/WhereConditionBuilderTest.java
+++ b/miaocha-server/src/test/java/com/hinadt/miaocha/mock/service/sql/builder/WhereConditionBuilderTest.java
@@ -52,7 +52,7 @@ class WhereConditionBuilderTest {
 
         String result = whereConditionBuilder.buildWhereConditions(dto);
 
-        assertEquals("level = 'ERROR'", result);
+        assertEquals("(level = 'ERROR')", result);
     }
 
     @Test
@@ -65,7 +65,8 @@ class WhereConditionBuilderTest {
 
         String result = whereConditionBuilder.buildWhereConditions(dto);
 
-        String expected = "(level = 'ERROR' AND service = 'user-service' AND host LIKE 'server-%')";
+        String expected =
+                "(level = 'ERROR') AND (service = 'user-service') AND (host LIKE 'server-%')";
         assertEquals(expected, result);
     }
 
@@ -78,7 +79,7 @@ class WhereConditionBuilderTest {
 
         String result = whereConditionBuilder.buildWhereConditions(dto);
 
-        String expected = "(level = 'ERROR' AND service = 'user-service')";
+        String expected = "(level = 'ERROR') AND (service = 'user-service')";
         assertEquals(expected, result);
     }
 
@@ -131,9 +132,9 @@ class WhereConditionBuilderTest {
         String result = whereConditionBuilder.buildWhereConditions(dto);
 
         String expected =
-                "(level = 'ERROR' AND service IN ('user', 'order') AND message LIKE '%timeout%' AND"
-                        + " log_time > DATE_SUB(NOW(), INTERVAL 1 HOUR) AND"
-                        + " variant_field['meta']['type'] = 'request')";
+                "(level = 'ERROR') AND (service IN ('user', 'order')) AND (message LIKE"
+                        + " '%timeout%') AND (log_time > DATE_SUB(NOW(), INTERVAL 1 HOUR)) AND"
+                        + " (variant_field['meta']['type'] = 'request')";
         assertEquals(expected, result);
     }
 }


### PR DESCRIPTION
Closes #139

## 变更的目的是什么

<!-- 请替换下面的XXXXX为实际内容，并删除这个注释 -->
修复日志主界面 where sql 查询拼接条件时，or 干扰整个 sql 语句执行，优先级错乱问题

## 简短的更新日志

<!-- 请替换下面的XX为实际内容，并删除这个注释 -->
强制 where sql 后续的子条件拼接时带上 (...) 防止出现优先级错乱
 
## 验证这一变化

<!-- 请替换下面的XXXX为实际内容，并删除这个注释 -->
XXXX

<!-- 请在每个checkbox前打勾 [x] 来确认已完成，并删除这个注释 -->
请遵循此清单，以帮助我们快速轻松地整合您的贡献：

* [x] 一个 PR（Pull Request的简写）只解决一个问题，禁止一个 PR 解决多个问题；
* [x] 确保 PR 有对应的 Issue（通常在您开始处理之前创建），除非是书写错误之类的琐碎更改不需要 Issue ；
* [x] 格式化 PR 及 Commit-Log 的标题及内容。PS：Commit-Log 需要在 Git Commit 代码时进行填写，在 GitHub 上修改不了；
* [x] 编写足够详细的 PR 描述，以了解 PR 的作用、方式和原因；
* [x] 编写必要的单元测试来验证您的逻辑更正。如果提交了新功能或重大更改，请记住在 test 模块中添加 integration-test；
* [x] 确保编译通过，集成测试通过；
