### PR TITLE
[ISSUE #163] Fix module mismatch in log field distribution and collapse issue

### DIFF
--- a/miaocha-ui/frontend/src/pages/Home/SearchBar/index.tsx
+++ b/miaocha-ui/frontend/src/pages/Home/SearchBar/index.tsx
@@ -69,8 +69,8 @@ const SearchBar = forwardRef<ISearchBarRef, ISearchBarProps>((props, ref) => {
   // 监听 searchParams 中的时间变化，同步更新 timeOption
   useEffect(() => {
     if (searchParams.startTime && searchParams.endTime) {
-      const newTimeString = `${searchParams.startTime} ~ ${searchParams.endTime}`;
-      const currentTimeString = `${timeState.timeOption?.range?.[0]} ~ ${timeState.timeOption?.range?.[1]}`;
+      const newTimeString = `${dayjs(searchParams.startTime).format('YYYY-MM-DD HH:mm:ss')} ~ ${dayjs(searchParams.endTime).format('YYYY-MM-DD HH:mm:ss')}`;
+      const currentTimeString = `${dayjs(timeState.timeOption?.range?.[0]).format('YYYY-MM-DD HH:mm:ss')} ~ ${dayjs(timeState.timeOption?.range?.[1]).format('YYYY-MM-DD HH:mm:ss')}`;
 
       // 如果 searchParams 中的时间与当前 timeOption 不一致，更新 timeOption
       if (currentTimeString !== newTimeString) {

--- a/miaocha-ui/frontend/src/pages/Home/SiderModule/hooks/index.ts
+++ b/miaocha-ui/frontend/src/pages/Home/SiderModule/hooks/index.ts
@@ -397,6 +397,19 @@ export const useModuleSelection = (
       if (onSelectedModuleChange) {
         onSelectedModuleChange(value, Number(datasourceId));
       }
+      const savedSearchParams = localStorage.getItem('searchBarParams');
+      if (savedSearchParams) {
+        try {
+          const params = JSON.parse(savedSearchParams);
+          const updatedParams = {
+            ...params,
+            module: value,
+          };
+          localStorage.setItem('searchBarParams', JSON.stringify(updatedParams));
+        } catch (error) {
+          console.error('更新localStorage中的searchBarParams失败:', error);
+        }
+      }
     },
     [modules, onSelectedModuleChange],
   );


### PR DESCRIPTION
## What does this PR do?

This PR fixes the bug reported in issue #163 where:
1. The log field distribution shows incorrect module instead of the selected one
2. After clearing browser cache, the field distribution details cannot be collapsed

## How does this PR address the issue?

- Fixed the module selection logic in log field distribution component
- Corrected the cache clearing mechanism to properly reset UI state
- Ensured field distribution details can be collapsed after cache operations

## Related Issue(s)

Closes #163

## Test Verification

- [x] Verified that the correct module is shown in field distribution
- [x] Confirmed field details can be collapsed after cache clearing
- [x] Tested with multiple module switches