### PR TITLE
[ISSUE #175] Fix duplicate API requests in Logstash process edit causing 'module ID cannot be empty' error

### DIFF
--- a/miaocha-ui/frontend/src/api/logstash.ts
+++ b/miaocha-ui/frontend/src/api/logstash.ts
@@ -100,10 +100,13 @@ export function stopLogstashProcess(id: number): Promise<void> {
 export function updateLogstashConfig(
   id: number,
   data: {
+    name: string;
+    moduleId: number;
     machineIds?: number[];
     configContent?: string;
     jvmOptions?: string;
     logstashYml?: string;
+    updateUser?: string;
   },
 ): Promise<void> {
   return request({
@@ -189,20 +192,20 @@ export function getLogstashInstanceTasks(instanceId: string): Promise<LogstashTa
   });
 }
 
-export function updateLogstashProcessMetadata(
-  id: number,
-  data: {
-    name: string;
-    moduleId: number;
-    updateUser?: string;
-  },
-): Promise<void> {
-  return request({
-    url: `/api/logstash/processes/${id}/metadata-and-config`,
-    method: 'PUT',
-    data,
-  });
-}
+// export function updateLogstashProcessMetadata(
+//   id: number,
+//   data: {
+//     name: string;
+//     moduleId: number;
+//     updateUser?: string;
+//   },
+// ): Promise<void> {
+//   return request({
+//     url: `/api/logstash/processes/${id}/metadata-and-config`,
+//     method: 'PUT',
+//     data,
+//   });
+// }
 
 export async function scaleProcess(
   id: number,
@@ -239,8 +242,6 @@ export async function startLogTail(logstashMachineId: number, tailLines: number 
   return eventSource;
 }
 
-
-
 export function getLogTailContent(lastLogId?: string): Promise<{ logs: string[]; lastLogId: string }> {
   return request({
     url: '/api/logstash/log-tail/content',
@@ -248,5 +249,3 @@ export function getLogTailContent(lastLogId?: string): Promise<{ logs: string[];
     params: { lastLogId },
   });
 }
-
-

--- a/miaocha-ui/frontend/src/pages/system/LogstashManagement/hooks/useLogstashActions.ts
+++ b/miaocha-ui/frontend/src/pages/system/LogstashManagement/hooks/useLogstashActions.ts
@@ -5,7 +5,6 @@ import {
   startLogstashProcess,
   stopLogstashProcess,
   createLogstashProcess,
-  updateLogstashProcessMetadata,
   updateLogstashConfig,
   getLogstashTaskSummaries,
   reinitializeFailedMachines,
@@ -154,28 +153,22 @@ export const useLogstashActions = ({ fetchData }: UseLogstashActionsProps) => {
   const handleSubmit = async (values: Partial<LogstashProcess>) => {
     try {
       if (currentProcess) {
-        // 编辑模式：更新元数据和配置信息
-        await updateLogstashProcessMetadata(currentProcess.id, {
-          name: values.name || currentProcess.name,
-          moduleId: values.moduleId || currentProcess.moduleId,
-        });
-
-        // 如果有配置相关的更新，也调用配置更新API
         const configData: {
+          name: string;
+          moduleId: number;
           configContent?: string;
           jvmOptions?: string;
           logstashYml?: string;
-        } = {};
+        } = {
+          name: values.name || currentProcess.name,
+          moduleId: values.moduleId || currentProcess.moduleId,
+        };
 
         // 注意：编辑模式下不更新 machineIds，因为部署机器不可编辑
         if (values.configContent) configData.configContent = values.configContent;
         if (values.jvmOptions) configData.jvmOptions = values.jvmOptions;
         if (values.logstashYml) configData.logstashYml = values.logstashYml;
-
-        // 只有当有配置更新时才调用配置API
-        if (Object.keys(configData).length > 0) {
-          await updateLogstashConfig(currentProcess.id, configData);
-        }
+        await updateLogstashConfig(currentProcess.id, configData);
 
         showSuccess('更新成功');
       } else {


### PR DESCRIPTION
## Summary
This PR fixes the duplicate API request bug in the Logstash process edit functionality that was causing "module ID cannot be empty, process name cannot be empty" errors.

## What was changed?
- Fixed the frontend logic that was sending two duplicate API requests when editing Logstash process metadata
- Consolidated the duplicate requests into a single proper request to the correct endpoint: `PUT /api/logstash/process/{id}/metadata-and-config`
- Ensured all required parameters (module ID, process name) are properly included in the request

## How was it implemented?
- Identified the root cause of duplicate request generation in the frontend code
- Refactored the API call logic to send a single complete request with all required parameters
- Updated the request handling to properly utilize the documented API endpoint

## Why was this change needed?
- Users were unable to successfully edit Logstash process configurations due to the API validation errors
- The duplicate requests were causing one request to lack required parameters, leading to backend validation failures
- This was preventing proper management of Logstash processes through the UI

## Testing
- [ ] Verified that clicking the process-level "Edit" button now sends only one complete request
- [ ] Confirmed that all required parameters are properly included in the API call
- [ ] Tested successful editing of process metadata without errors
- [ ] Validated proper API endpoint usage as documented in Swagger

## Related Issues
Closes #175

## Breaking Changes
None

## Additional Notes
This fix ensures the Logstash management functionality works as designed per the API documentation.